### PR TITLE
Implement ast.Pow Operator Rewriting Rule in AstRewriter

### DIFF
--- a/qlasskit/ast2ast.py
+++ b/qlasskit/ast2ast.py
@@ -592,7 +592,14 @@ class ASTRewriter(ast.NodeTransformer):
                 for _ in range(node.right.value - 1):
                     result = ast.BinOp(left=result, op=ast.Mult(), right=node.left)
                 return result
+            elif (
+                isinstance(node.right, ast.Constant)
+                and isinstance(node.right.value, int)
+                and node.right.value == 0
+            ):
+                return ast.Constant(value=1)
         return super().generic_visit(node)
+
 
 def ast2ast(a_tree):
     # print(ast.dump(a_tree))

--- a/qlasskit/ast2ast.py
+++ b/qlasskit/ast2ast.py
@@ -580,18 +580,18 @@ class ASTRewriter(ast.NodeTransformer):
             return node
 
     def visit_BinOp(self, node):
-        # ensure the right operand is an ast.constant and a positive integer
+        # rewrite the ** operator to be a series of multiplications
         if isinstance(node.op, ast.Pow):
             if (
                 isinstance(node.right, ast.Constant)
                 and isinstance(node.right.value, int)
                 and node.right.value > 0
             ):
-                # generate a series of multiplications
                 result = node.left
                 for _ in range(node.right.value - 1):
                     result = ast.BinOp(left=result, op=ast.Mult(), right=node.left)
                 return result
+
             elif (
                 isinstance(node.right, ast.Constant)
                 and isinstance(node.right.value, int)

--- a/qlasskit/ast2ast.py
+++ b/qlasskit/ast2ast.py
@@ -579,6 +579,20 @@ class ASTRewriter(ast.NodeTransformer):
         else:
             return node
 
+    def visit_BinOp(self, node):
+        # ensure the right operand is an ast.constant and a positive integer
+        if isinstance(node.op, ast.Pow):
+            if (
+                isinstance(node.right, ast.Constant)
+                and isinstance(node.right.value, int)
+                and node.right.value > 0
+            ):
+                # generate a series of multiplications
+                result = node.left
+                for _ in range(node.right.value - 1):
+                    result = ast.BinOp(left=result, op=ast.Mult(), right=node.left)
+                return result
+        return super().generic_visit(node)
 
 def ast2ast(a_tree):
     # print(ast.dump(a_tree))

--- a/qlasskit/types/qint.py
+++ b/qlasskit/types/qint.py
@@ -219,6 +219,10 @@ class QintImp(int, Qtype):
             else:
                 raise Exception(f"Mul result size is too big ({n+m})")
 
+        def pad_operand(operand, size):
+            padded_value = operand[1] + [False] * (size - len(operand[1]))
+            return operand[0], padded_value
+
         # Fill constants so explicit typecast is not needed
         if cls.is_const(tleft_):
             tleft = tright_[0].fill(tleft_)
@@ -233,6 +237,15 @@ class QintImp(int, Qtype):
         n = len(tleft[1])
         m = len(tright[1])
 
+        # Ensure same size operands by padding the smaller one
+        if n != m:
+            if n > m:
+                tright = pad_operand(tright, n)
+                m = n
+            else:
+                tleft = pad_operand(tleft, m)
+                n = m
+
         # If one operand is an even constant, use mul_even_const
         if cls.is_const(tleft) or cls.is_const(tright):
             t_num = tleft if cls.is_const(tright) else tright
@@ -244,8 +257,8 @@ class QintImp(int, Qtype):
                 res = cls.mul_even_const(t_num, const, t)
                 return t.crop(t.fill(res))
 
-        if n != m:
-            raise Exception(f"Mul works only on same size Qint: {n} != {m}")
+        # if n != m:
+        #     raise Exception(f"Mul works only on same size Qint: {n} != {m}")
 
         product = [False] * (n + m)
 

--- a/test/qlassf/test_int.py
+++ b/test/qlassf/test_int.py
@@ -513,3 +513,21 @@ class TestQlassfIntMulByConst(unittest.TestCase):
         f = f"def test(a: Qint[{self.ttype_i}]) -> Qint[{self.ttype_o}]: return a * {self.const}"
         qf = qlassf(f, to_compile=COMPILATION_ENABLED, compiler=self.compiler)
         compute_and_compare_results(self, qf)
+
+
+@parameterized_class(("compiler"), ENABLED_COMPILERS)
+class TestQlassfIntPow(unittest.TestCase):
+    def test_pow_const(self):
+        f = "def test(a: Qint[4]) -> Qint[8]: return a ** 2"
+        qf = qlassf(f, to_compile=COMPILATION_ENABLED)
+        compute_and_compare_results(self, qf)
+
+    def test_pow_const2(self):
+        f = "def test(a: Qint[4]) -> Qint[16]: return a ** 3"
+        qf = qlassf(f, to_compile=COMPILATION_ENABLED)
+        compute_and_compare_results(self, qf)
+
+    def test_pow_zero(self):
+        f = "def test(a: Qint[4]) -> Qint[4]: return a ** 0"
+        qf = qlassf(f, to_compile=COMPILATION_ENABLED)
+        compute_and_compare_results(self, qf)

--- a/test/test_ast_rewriter.py
+++ b/test/test_ast_rewriter.py
@@ -58,7 +58,3 @@ class TestASTRewriter(unittest.TestCase):
         expected_tree = ast.parse(expected_code)
 
         self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_ast_rewriter.py
+++ b/test/test_ast_rewriter.py
@@ -1,0 +1,64 @@
+# Copyright 2023-204 Davide Gessa
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import unittest
+
+from qlasskit.ast2ast import ASTRewriter
+
+
+class TestASTRewriter(unittest.TestCase):
+
+    def setUp(self):
+        self.rewriter = ASTRewriter()
+
+    def test_exponentiation_transformation(self):
+        # Test case for a ** 3
+        code = "a = b ** 3"
+        tree = ast.parse(code)
+        new_tree = self.rewriter.visit(tree)
+
+        # Expected transformation
+        expected_code = "a = b * b * b"
+        expected_tree = ast.parse(expected_code)
+
+        self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
+
+    def test_non_exponentiation(self):
+        # Test case for non-exponentiation
+        code = "a = b + 3"
+        tree = ast.parse(code)
+        new_tree = self.rewriter.visit(tree)
+
+        # Expected transformation (should be the same)
+        expected_code = "a = b + 3"
+        expected_tree = ast.parse(expected_code)
+
+        self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
+
+    def test_exponentiation_with_non_constant(self):
+        # Test case for a ** b (non-constant exponent)
+        code = "a = b ** c"
+        tree = ast.parse(code)
+        new_tree = self.rewriter.visit(tree)
+
+        # Expected transformation (should be the same)
+        expected_code = "a = b ** c"
+        expected_tree = ast.parse(expected_code)
+
+        self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_ast_rewriter.py
+++ b/test/test_ast_rewriter.py
@@ -24,37 +24,41 @@ class TestASTRewriter(unittest.TestCase):
         self.rewriter = ASTRewriter()
 
     def test_exponentiation_transformation(self):
-        # Test case for a ** 3
         code = "a = b ** 3"
         tree = ast.parse(code)
         new_tree = self.rewriter.visit(tree)
 
-        # Expected transformation
         expected_code = "a = b * b * b"
         expected_tree = ast.parse(expected_code)
 
         self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
 
     def test_non_exponentiation(self):
-        # Test case for non-exponentiation
         code = "a = b + 3"
         tree = ast.parse(code)
         new_tree = self.rewriter.visit(tree)
 
-        # Expected transformation (should be the same)
         expected_code = "a = b + 3"
         expected_tree = ast.parse(expected_code)
 
         self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
 
     def test_exponentiation_with_non_constant(self):
-        # Test case for a ** b (non-constant exponent)
         code = "a = b ** c"
         tree = ast.parse(code)
         new_tree = self.rewriter.visit(tree)
 
-        # Expected transformation (should be the same)
         expected_code = "a = b ** c"
+        expected_tree = ast.parse(expected_code)
+
+        self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))
+
+    def test_exponentiation_with_zero(self):
+        code = "a = b ** 0"
+        tree = ast.parse(code)
+        new_tree = self.rewriter.visit(tree)
+
+        expected_code = "a = 1"
         expected_tree = ast.parse(expected_code)
 
         self.assertEqual(ast.dump(new_tree), ast.dump(expected_tree))


### PR DESCRIPTION
### Description:

This PR addresses the issue of implementing the `ast.Pow` operator (`**`) between a variable and an integer constant. The goal is to rewrite the exponentiation operation as a series of multiplication operations. The following changes have been made:

- Modified `visit_BinOp` method to handle `ast.Pow` nodes:
  - Checks if the operation is an exponentiation and the right operand is a positive integer constant.
  - Rewrites `a ** n` as `a * a * ... * a` (n times).
- Did not override `visit_Pow` because `ast.Pow` is not visited directly but as part of `ast.BinOp`.

### Testing:

- Added unit tests in test_ast_rewriter.py
- Verified that `a ** n` is correctly transformed into `a * a * ... * a` for positive integer constants.
- Ensured that other binary operations are processed correctly by the `visit_BinOp` method.

### Explanation:

I focused on overriding the `visit_BinOp` method to handle the `ast.Pow` operator. My understanding is that `visit_Pow` is not applicable here because `ast.Pow` is an operator within a `BinOp` node rather than a standalone node. Thus, `visit_BinOp` seemed to be the appropriate place to implement this transformation. I'm not entirely sure if this is the best approach, but it appears to work based on my testing.

### Related Issue:

This PR resolves issue #23 

---

Please review these changes and provide feedback :smile: 