### PR TITLE
Add py2bexp CLI tool to convert qlassf functions to boolean expressions

### DIFF
--- a/qlasskit/tools/py2bexp.py
+++ b/qlasskit/tools/py2bexp.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+# Copyright 2023-2024 Davide Gessa
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+import sympy
+import qlasskit
+from qlasskit.qlassfun import QlassF
+from qlasskit.tools.utils import parse_str
+
+
+def read_input(input_file):
+    if input_file == "-":
+        return sys.stdin.read()
+    with open(input_file, "r") as file:
+        return file.read()
+
+
+def find_last_qlassf(qlassf_list):
+    return qlassf_list[-1][1] if qlassf_list else None
+
+
+def convert_to_bool_expression(qlassf: QlassF, form: str):
+    combined_expr = sympy.And(*[expr[1] for expr in qlassf.expressions])
+
+    if form == "anf":
+        return sympy.to_anf(combined_expr)
+    elif form == "cnf":
+        return sympy.to_cnf(combined_expr, simplify=True)
+    elif form == "dnf":
+        return sympy.to_dnf(combined_expr, simplify=True)
+    elif form == "nnf":
+        return sympy.to_nnf(combined_expr, simplify=True)
+    return combined_expr  # Default case if no specific form is requested
+
+
+def convert_to_dimacs(expr):
+    clauses = sympy.to_cnf(expr, simplify=True).args
+    if len(clauses) == 1 and isinstance(clauses[0], sympy.Symbol):
+        clauses = [clauses]
+
+    var_dict = {symbol: i + 1 for i, symbol in enumerate(expr.free_symbols)}
+    dimacs_clauses = []
+
+    for clause in clauses:
+        if isinstance(clause, sympy.Or):
+            clause_literals = clause.args
+        else:
+            clause_literals = [clause]
+
+        dimacs_clause = []
+        for lit in clause_literals:
+            if isinstance(lit, sympy.Not):
+                dimacs_clause.append(-var_dict[lit.args[0]])
+            else:
+                dimacs_clause.append(var_dict[lit])
+        dimacs_clauses.append(dimacs_clause)
+
+    num_vars = len(var_dict)
+    num_clauses = len(dimacs_clauses)
+    dimacs_str = f"p cnf {num_vars} {num_clauses}\n"
+    for clause in dimacs_clauses:
+        dimacs_str += " ".join(map(str, clause)) + " 0\n"
+    return dimacs_str
+
+
+def output_result(result, output_file, output_format):
+    if output_format == "dimacs":
+        result = convert_to_dimacs(result)
+    if output_file == "-":
+        print(result)
+    else:
+        with open(output_file, "w") as file:
+            file.write(str(result))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert qlassf functions in a Python script to boolean expressions."
+    )
+    parser.add_argument(
+        "-i", "--input-file", default="-", help="Input file (default: stdin)"
+    )
+    parser.add_argument("-e", "--entrypoint", help="Entrypoint function name")
+    parser.add_argument(
+        "-o", "--output", default="-", help="Output file (default: stdout)"
+    )
+    parser.add_argument(
+        "-f",
+        "--form",
+        choices=["anf", "cnf", "dnf", "nnf"],
+        default="sympy",
+        help="Expression form (default: sympy)",
+    )
+    parser.add_argument(
+        "-t",
+        "--format",
+        choices=["sympy", "dimacs"],
+        default="sympy",
+        help="Output format (default: sympy)",
+    )
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"qlasskit {qlasskit.__version__}"
+    )
+
+    args = parser.parse_args()
+
+    script = read_input(args.input_file)
+    qlassf_list = parse_str(script)
+
+    if args.entrypoint:
+        qlassf = next((f[1] for f in qlassf_list if f[0] == args.entrypoint), None)
+    else:
+        qlassf = find_last_qlassf(qlassf_list)
+
+    if qlassf:
+        bool_expr = convert_to_bool_expression(qlassf, args.form)
+        output_result(bool_expr, args.output, args.format)
+    else:
+        print("No qlassf function found", file=sys.stderr)

--- a/qlasskit/tools/py2bexp.py
+++ b/qlasskit/tools/py2bexp.py
@@ -16,7 +16,9 @@
 
 import argparse
 import sys
+
 import sympy
+
 import qlasskit
 from qlasskit.qlassfun import QlassF
 from qlasskit.tools.utils import parse_str
@@ -131,3 +133,7 @@ def main():
         output_result(bool_expr, args.output, args.format)
     else:
         print("No qlassf function found", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/qlasskit/tools/py2bexp.py
+++ b/qlasskit/tools/py2bexp.py
@@ -24,16 +24,14 @@ import qlasskit
 from qlasskit.qlassfun import QlassF
 from qlasskit.tools.utils import parse_str
 
+from .tools import find_last_qlassf
+
 
 def read_input(input_file):
     if input_file == "-":
         return sys.stdin.read()
     with open(input_file, "r") as file:
         return file.read()
-
-
-def find_last_qlassf(qlassf_list):
-    return qlassf_list[-1][1] if qlassf_list else None
 
 
 def convert_to_bool_expression(qlassf: QlassF, form: str):

--- a/qlasskit/tools/tools.py
+++ b/qlasskit/tools/tools.py
@@ -1,0 +1,17 @@
+# Copyright 2023-2024 Davide Gessa
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def find_last_qlassf(qlassf_list):
+    return qlassf_list[-1][1] if qlassf_list else None

--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,9 @@ setup(
         "Documentation": "https://dakk.github.io/qlasskit",
         "Source": "https://github.com/dakk/qlasskit",
     },
+    entry_points={
+        "console_scripts": [
+            "py2bexp=qlasskit.tools.py2bexp:main",
+        ]
+    },
 )

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -17,6 +17,11 @@ import subprocess
 import tempfile
 import unittest
 
+import sympy
+from sympy.logic.boolalg import is_anf, is_cnf, is_dnf, is_nnf
+from sympy.logic.utilities.dimacs import load
+
+import qlasskit
 from qlasskit.tools import utils
 
 dummy_script = """
@@ -48,11 +53,19 @@ class TestPy2Bexp(unittest.TestCase):
         # Remove the temporary file
         os.unlink(self.temp_file.name)
 
-    def run_command(self, args, input=None):
-        result = subprocess.run(args, input=input, capture_output=True, text=True)
-        if result.stderr:
-            print(f"Error: {result.stderr}")
-        return result
+    def run_command(self, args, stdin_input=None):
+        try:
+            result = subprocess.run(
+                args, input=stdin_input, capture_output=True, text=True, check=True
+            )
+            return result
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Command '{' '.join(e.cmd)}' returned non-zero exit status {e.returncode}"
+            )
+            print(f"Standard output:\n{e.stdout}")
+            print(f"Standard error:\n{e.stderr}")
+            raise
 
     def test_help(self):
         result = self.run_command(["python", "-m", "qlasskit.tools.py2bexp", "--help"])
@@ -63,12 +76,16 @@ class TestPy2Bexp(unittest.TestCase):
             ["python", "-m", "qlasskit.tools.py2bexp", "--version"]
         )
         print(result.stdout)
+        assert result.stdout == f"qlasskit {qlasskit.__version__}\n"
 
     def test_output_to_stdout(self):
         result = self.run_command(
             ["python", "-m", "qlasskit.tools.py2bexp", "-i", self.temp_file.name]
         )
         print(result.stdout)
+        expr = sympy.parse_expr(result.stdout)
+        expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        assert expr.equals(expected)
 
     def test_specific_entrypoint(self):
         result = self.run_command(
@@ -83,7 +100,9 @@ class TestPy2Bexp(unittest.TestCase):
             ]
         )
         print(result.stdout)
-        self.assertIn("~b", result.stdout)  # For function a(b)
+        expr = sympy.parse_expr(result.stdout)
+        expected = sympy.parse_expr("~b")
+        assert expr.equals(expected)
 
     def test_output_to_file(self):
         with tempfile.NamedTemporaryFile(delete=False) as temp_output:
@@ -103,6 +122,9 @@ class TestPy2Bexp(unittest.TestCase):
             with open(output_file, "r") as f:
                 content = f.read()
                 print(content)
+                expr = sympy.parse_expr(content)
+                expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+                assert expr.equals(expected)
         finally:
             os.unlink(output_file)
 
@@ -119,6 +141,10 @@ class TestPy2Bexp(unittest.TestCase):
             ]
         )
         print(result.stdout)
+        expr = sympy.parse_expr(result.stdout)
+        expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        assert expr.equals(expected)
+        assert is_dnf(result.stdout)
 
     def test_cnf_form(self):
         result = self.run_command(
@@ -133,6 +159,47 @@ class TestPy2Bexp(unittest.TestCase):
             ]
         )
         print(result.stdout)
+        expr = sympy.parse_expr(result.stdout)
+        expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        assert expr.equals(expected)
+        assert is_cnf(result.stdout)
+
+    def test_nnf_form(self):
+        result = self.run_command(
+            [
+                "python",
+                "-m",
+                "qlasskit.tools.py2bexp",
+                "-i",
+                self.temp_file.name,
+                "-f",
+                "nnf",
+            ]
+        )
+        print(result.stdout)
+        expr = sympy.parse_expr(result.stdout)
+        expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        assert expr.equals(expected)
+        assert is_nnf(result.stdout)
+
+    def test_anf_form(self):
+        result = self.run_command(
+            [
+                "python",
+                "-m",
+                "qlasskit.tools.py2bexp",
+                "-i",
+                self.temp_file.name,
+                "-f",
+                "anf",
+            ]
+        )
+        print(result.stdout)
+        expr = sympy.parse_expr(result.stdout)
+        print(expr)
+        expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        assert expr.equals(expected)
+        # assert is_anf(result.stdout) # This is not working
 
     def test_dimacs_format(self):
         result = self.run_command(
@@ -149,9 +216,17 @@ class TestPy2Bexp(unittest.TestCase):
             ]
         )
         print(result.stdout)
+        expr = load(result.stdout)
+        print(expr)
+        # expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        # assert expr.equals(expected)
+        self.assertIn("p cnf 3 2", result.stdout)
 
     def test_stdin_input(self):
         result = self.run_command(
-            ["python", "-m", "qlasskit.tools.py2bexp"], input=dummy_script
+            ["python", "-m", "qlasskit.tools.py2bexp"], stdin_input=dummy_script
         )
         print(result.stdout)
+        expr = sympy.parse_expr(result.stdout)
+        expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
+        assert expr.equals(expected)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -55,21 +55,27 @@ class TestPy2Bexp(unittest.TestCase):
         return result
 
     def test_help(self):
-        result = self.run_command(["py2bexp", "--help"])
+        result = self.run_command(["python", "-m", "qlasskit.tools.py2bexp", "--help"])
         print(result.stdout)
 
     def test_version(self):
-        result = self.run_command(["py2bexp", "--version"])
+        result = self.run_command(
+            ["python", "-m", "qlasskit.tools.py2bexp", "--version"]
+        )
         print(result.stdout)
 
     def test_output_to_stdout(self):
-        result = self.run_command(["py2bexp", "-i", self.temp_file.name])
+        result = self.run_command(
+            ["python", "-m", "qlasskit.tools.py2bexp", "-i", self.temp_file.name]
+        )
         print(result.stdout)
 
     def test_specific_entrypoint(self):
         result = self.run_command(
             [
-                "py2bexp",
+                "python",
+                "-m",
+                "qlasskit.tools.py2bexp",
                 "-i",
                 self.temp_file.name,
                 "-e",
@@ -85,7 +91,9 @@ class TestPy2Bexp(unittest.TestCase):
         try:
             self.run_command(
                 [
-                    "py2bexp",
+                    "python",
+                    "-m",
+                    "qlasskit.tools.py2bexp",
                     "-i",
                     self.temp_file.name,
                     "-o",
@@ -101,7 +109,9 @@ class TestPy2Bexp(unittest.TestCase):
     def test_dnf_form(self):
         result = self.run_command(
             [
-                "py2bexp",
+                "python",
+                "-m",
+                "qlasskit.tools.py2bexp",
                 "-i",
                 self.temp_file.name,
                 "-f",
@@ -113,7 +123,9 @@ class TestPy2Bexp(unittest.TestCase):
     def test_cnf_form(self):
         result = self.run_command(
             [
-                "py2bexp",
+                "python",
+                "-m",
+                "qlasskit.tools.py2bexp",
                 "-i",
                 self.temp_file.name,
                 "-f",
@@ -125,7 +137,9 @@ class TestPy2Bexp(unittest.TestCase):
     def test_dimacs_format(self):
         result = self.run_command(
             [
-                "py2bexp",
+                "python",
+                "-m",
+                "qlasskit.tools.py2bexp",
                 "-i",
                 self.temp_file.name,
                 "-f",
@@ -137,5 +151,7 @@ class TestPy2Bexp(unittest.TestCase):
         print(result.stdout)
 
     def test_stdin_input(self):
-        result = self.run_command(["py2bexp"], input=dummy_script)
+        result = self.run_command(
+            ["python", "-m", "qlasskit.tools.py2bexp"], input=dummy_script
+        )
         print(result.stdout)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -18,7 +18,7 @@ import tempfile
 import unittest
 
 import sympy
-from sympy.logic.boolalg import is_cnf, is_dnf, is_nnf
+from sympy.logic.boolalg import And, Not, Or, is_cnf, is_dnf, is_nnf
 
 # from sympy.logic.boolalg import to_anf
 from sympy.logic.utilities.dimacs import load
@@ -219,9 +219,24 @@ class TestPy2Bexp(unittest.TestCase):
         )
         print(result.stdout)
         expr = load(result.stdout)
-        print(expr)
-        # expected = sympy.parse_expr("(x | y | ~z) & (z | ~y)")
-        # assert expr.equals(expected)
+        symbols = expr.free_symbols
+        x, y, z = symbols
+        expected1 = And(Or(x, y, Not(z)), Or(z, Not(y)))
+        expected2 = And(Or(y, z, Not(x)), Or(x, Not(z)))
+        expected3 = And(Or(z, x, Not(y)), Or(y, Not(x)))
+        expected4 = And(Or(x, z, Not(y)), Or(y, Not(z)))
+        expected5 = And(Or(y, x, Not(z)), Or(z, Not(x)))
+        expected6 = And(Or(z, y, Not(x)), Or(x, Not(y)))
+        # The result should be one of the 6 permutations of the expected expressions
+        # because the order of the symbols in the DIMACS format is not guaranteed
+        assert (
+            expr.equals(expected1)
+            or expr.equals(expected2)
+            or expr.equals(expected3)
+            or expr.equals(expected4)
+            or expr.equals(expected5)
+            or expr.equals(expected6)
+        )
         self.assertIn("p cnf 3 2", result.stdout)
 
     def test_stdin_input(self):

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,22 +1,25 @@
-# Copyright 2023-204 Davide Gessa
-
+# Copyright 2023-2024 Davide Gessa
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import subprocess
+import tempfile
 import unittest
 
 from qlasskit.tools import utils
 
-dummy = """
+dummy_script = """
 from qlasskit import qlassf
 
 @qlassf
@@ -24,11 +27,115 @@ def a(b: bool) -> bool:
     return not b
 
 @qlassf
-def c(b: bool) -> bool:
-    return b
+def c(x: bool, y: bool, z: bool) -> bool:
+    return (x or y or not z) and (not y or z)
 """
 
 
 class TestTools_utils(unittest.TestCase):
     def test_parse_str(self):
-        print(utils.parse_str(dummy))
+        print(utils.parse_str(dummy_script))
+
+
+class TestPy2Bexp(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary file to hold the dummy script
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".py")
+        self.temp_file.write(dummy_script.encode())
+        self.temp_file.close()
+
+    def tearDown(self):
+        # Remove the temporary file
+        os.unlink(self.temp_file.name)
+
+    def run_command(self, args, input=None):
+        result = subprocess.run(args, input=input, capture_output=True, text=True)
+        if result.stderr:
+            print(f"Error: {result.stderr}")
+        return result
+
+    def test_help(self):
+        result = self.run_command(["py2bexp", "--help"])
+        print(result.stdout)
+
+    def test_version(self):
+        result = self.run_command(["py2bexp", "--version"])
+        print(result.stdout)
+
+    def test_output_to_stdout(self):
+        result = self.run_command(["py2bexp", "-i", self.temp_file.name])
+        print(result.stdout)
+
+    def test_specific_entrypoint(self):
+        result = self.run_command(
+            [
+                "py2bexp",
+                "-i",
+                self.temp_file.name,
+                "-e",
+                "a",
+            ]
+        )
+        print(result.stdout)
+        self.assertIn("~b", result.stdout)  # For function a(b)
+
+    def test_output_to_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as temp_output:
+            output_file = temp_output.name
+        try:
+            self.run_command(
+                [
+                    "py2bexp",
+                    "-i",
+                    self.temp_file.name,
+                    "-o",
+                    output_file,
+                ]
+            )
+            with open(output_file, "r") as f:
+                content = f.read()
+                print(content)
+        finally:
+            os.unlink(output_file)
+
+    def test_dnf_form(self):
+        result = self.run_command(
+            [
+                "py2bexp",
+                "-i",
+                self.temp_file.name,
+                "-f",
+                "dnf",
+            ]
+        )
+        print(result.stdout)
+
+    def test_cnf_form(self):
+        result = self.run_command(
+            [
+                "py2bexp",
+                "-i",
+                self.temp_file.name,
+                "-f",
+                "cnf",
+            ]
+        )
+        print(result.stdout)
+
+    def test_dimacs_format(self):
+        result = self.run_command(
+            [
+                "py2bexp",
+                "-i",
+                self.temp_file.name,
+                "-f",
+                "cnf",
+                "-t",
+                "dimacs",
+            ]
+        )
+        print(result.stdout)
+
+    def test_stdin_input(self):
+        result = self.run_command(["py2bexp"], input=dummy_script)
+        print(result.stdout)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -18,7 +18,9 @@ import tempfile
 import unittest
 
 import sympy
-from sympy.logic.boolalg import is_anf, is_cnf, is_dnf, is_nnf
+from sympy.logic.boolalg import is_cnf, is_dnf, is_nnf
+
+# from sympy.logic.boolalg import to_anf
 from sympy.logic.utilities.dimacs import load
 
 import qlasskit


### PR DESCRIPTION
**Summary:**

This pull request introduces the `py2bexp` command-line tool to the `qlasskit` package. The tool converts qlassf functions in a Python script to boolean expressions. It also includes initial tests for the functionality.

**Changes:**

1. **Added `py2bexp.py` to `qlasskit/tools` package:**
   - Implements the conversion of qlassf functions to boolean expressions.
   - Supports reading from a file or stdin.
   - Allows specifying entrypoint function, output file, expression form, and output format.
   - Includes command-line arguments parsing with `argparse`.

2. **Updated `setup.py`:**
   - Added `py2bexp` as a console script entry point for seamless installation and usage.

3. **Initial Tests in `test_tools.py`:**
   - Included tests for help and version commands.
   - Added tests for default behavior, specific entrypoint, and different expression forms.
   - Verified DIMACS format output for CNF.
   - **Note**: Tests currently do not have assertions but printing results looks good.
       - I don't know what kind of assertion would be appropriate...
   
**Related Issue:**

This PR resolves issue #28

@dakk, I'm looking forward to your feedback.