### PR TITLE
Update exporter_cirq.py

### DIFF
--- a/qlasskit/qcircuit/exporter_cirq.py
+++ b/qlasskit/qcircuit/exporter_cirq.py
@@ -47,7 +47,7 @@ class CirqExporter(QCircuitExporter):
                             gg = cirq.ControlledGate(
                                 sub_gate=cirq.X, num_controls=len(w) - 1
                             )
-                            yield gg(list(map(lambda wx: qubits[w], w)))
+                            yield gg(*(qubits[i] for i in w))
 
                         elif isinstance(g, gates.MCtrl) and isinstance(g.gate, gates.Z):
                             gg = cirq.ControlledGate(

--- a/qlasskit/qcircuit/exporter_cirq.py
+++ b/qlasskit/qcircuit/exporter_cirq.py
@@ -53,7 +53,7 @@ class CirqExporter(QCircuitExporter):
                             gg = cirq.ControlledGate(
                                 sub_gate=cirq.Z, num_controls=len(w) - 1
                             )
-                            yield gg(list(map(lambda wx: qubits[w], w)))
+                            yield gg(*(qubits[i] for i in w))
 
                         elif isinstance(g, gates.Swap):
                             yield cirq.SWAP(qubits[w[0]], qubits[w[1]])


### PR DESCRIPTION
An error was encountered while exporting the generic Toffoli gate in question to Cirq, specifically a 'TypeError: tuple indices must be integers or slices, not list.' It was modified in the code, and it worked. The other parts related to the gates were not changed because they were not tested.